### PR TITLE
Bump to 2.10.4

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,19 +11,19 @@ jobs:
       linux_64_python3.6.____cpython:
         CONFIG: linux_64_python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.7.____cpython:
         CONFIG: linux_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.8.____cpython:
         CONFIG: linux_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_python3.9.____cpython:
         CONFIG: linux_64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -1,9 +1,11 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -1,9 +1,11 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -1,9 +1,11 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -1,9 +1,11 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brainstorm
+* @brainstorm @tschoonj

--- a/README.md
+++ b/README.md
@@ -193,4 +193,5 @@ Feedstock Maintainers
 =====================
 
 * [@brainstorm](https://github.com/brainstorm/)
+* [@tschoonj](https://github.com/tschoonj/)
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,5 @@
+pushd base
+$PYTHON -m pip install . -vv
+popd
+
+$PYTHON -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,3 +62,4 @@ about:
 extra:
   recipe-maintainers:
     - brainstorm
+    - tschoonj

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ansible" %}
-{% set version = "2.9.13" %}
-{% set sha256 = "3ab21588992fbfe9de3173aefd63da1267dc12892a60f5cfdc055fe19c549644" %}
+{% set version = "2.10.4" %}
+{% set base_version = "2.10.3" %}
 
 
 package:
@@ -8,13 +8,14 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 98e718aea82199be62db7731373d660627aa1e938d34446588f2f49c228638ee
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}-base/{{ name }}-base-{{ base_version }}.tar.gz
+    sha256: 35a208726b10fecbcf00c263ae4572b48f505b5796fb77a85c3e9c1036ea5e4f
+    folder: base
 
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
   skip: true  # [win]
 
 requirements:
@@ -36,6 +37,8 @@ requirements:
     - boto
 
 test:
+  commands:
+    - ansible --version
   imports:
     - ansible
     - ansible.constants


### PR DESCRIPTION
In 2.10 Ansible was split up in a base package containing the core functionality, and the collections which can be installed using ansible-galaxy.
On PyPI, ansible is now a meta package that pulls in ansible-base, as well as all collections that were present in previous releases.

This PR install the pip packages ansible-base and ansible, and produces a package that is very similar to those produced previously.